### PR TITLE
Fix players controller

### DIFF
--- a/app/controllers/api/v1/tournament/players_controller.rb
+++ b/app/controllers/api/v1/tournament/players_controller.rb
@@ -4,24 +4,18 @@ module Api
   module V1
     module Tournament
       class PlayersController < ApplicationController
-        before_action :set_organization
         before_action :set_tournament
         before_action :set_players, only: %i[index create]
         before_action :set_player, only: %i[show update destroy]
 
-        # GET /api/v1/tournaments/:tournament_id/players
-        # GET /api/v1/tournaments/:tournament_id/players.json
         def index
           render json: @players, each_serializer: ::PlayerSerializer, status: :ok
         end
 
-        # GET /api/v1/tournaments/:tournament_id/players/:id
-        # GET /api/v1/tournaments/:tournament_id/players/:id.json
         def show
           render json: serialize_player_details, status: :ok
         end
 
-        # POST /api/v1/tournaments/:tournament_id/players
         def create
           @player = @players.create! permitted_params.merge(tournament_id: @tournament.id)
           if @player.save
@@ -33,8 +27,6 @@ module Api
           render json: { error: e.message }, status: :bad_request
         end
 
-        # PATCH/PUT /api/v1/tournaments/:tournament_id/players/:id
-        # PATCH/PUT /api/v1/tournaments/:tournament_id/players/:id.json
         def update
           if @player.update! permitted_params
             render json: serialize_player_details, status: :ok
@@ -43,8 +35,6 @@ module Api
           end
         end
 
-        # DELETE /api/v1/tournaments/:tournament_id/players/:id
-        # DELETE /api/v1/tournaments/:tournament_id/players/:id.json
         def destroy
           @player.destroy!
           render json: { message: 'Player deleted' }, status: :ok
@@ -72,22 +62,14 @@ module Api
         end
 
         def set_tournament
-          @organization ||= set_organization
-          @tournament = @organization.tournaments.find(params[:tournament_id])
+          @tournament ||= ::Tournament::Tournament.find(params[:tournament_id])
           @tournament
         rescue ActiveRecord::RecordNotFound
           render json: { error: 'Tournament not found' }, status: :not_found
         end
 
-        def set_organization
-          @organization = ::Organization::Organization.find(params[:organization_id])
-          @organization
-        rescue ActiveRecord::RecordNotFound
-          render json: { error: 'Organization not found' }, status: :not_found
-        end
-
         def permitted_params
-          params.require(:player).permit(:user_id, :username, :in_game_name)
+          params.require(:player).permit(:user_id, :username, :in_game_name, organization_id: params[:organization_id])
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,14 +37,13 @@ Rails.application.routes.draw do
         member do
           get 'staff', to: 'organizations#staff'
         end
-        resources :tournaments, only: %i[index show create update destroy] do
-          resources :players, only: %i[index show create update destroy], controller: 'tournament/players'
-        end
+        resources :tournaments, only: %i[index show create update destroy]
       end
 
       resources :tournaments do
         resources :phases, only: %i[index show create update destroy], controller: 'tournament/phases'
         resources :matches, only: %i[index create update]
+        resources :players, only: %i[index show create update destroy], controller: 'tournament/players'
       end
     end
   end

--- a/spec/requests/api/v1/tournaments/players_spec.rb
+++ b/spec/requests/api/v1/tournaments/players_spec.rb
@@ -2,14 +2,13 @@ require 'swagger_helper'
 require_relative '../../../../support/openapi/schema_helper'
 require_relative '../../../../support/openapi/response_helper'
 
-RSpec.describe 'api/v1/organizations/:organization_id/tournaments/:tournament_id/players' do
+RSpec.describe 'api/v1/tournaments/:tournament_id/players' do
   let(:organization) { create(:organization) }
   let(:organization_id) { organization.id }
   let(:tournament) { create(:tournament, organization:) }
   let(:tournament_id) { tournament.id }
 
-  path('/api/v1/organizations/{organization_id}/tournaments/{tournament_id}/players') do
-    parameter name: :organization_id, in: :path, type: :integer, description: 'ID of the Organization', required: true
+  path('/api/v1/tournaments/{tournament_id}/players') do
     parameter name: :tournament_id, in: :path, type: :integer, description: 'ID of the Tournament', required: true
 
     get('List Tournament Players') do
@@ -55,6 +54,8 @@ RSpec.describe 'api/v1/organizations/:organization_id/tournaments/:tournament_id
           }
         }
       }
+
+      parameter name: :organization_id, in: :path, type: :integer, description: 'ID of the Organization', required: true
 
       response(201, 'created') do
         let(:player) do
@@ -102,8 +103,7 @@ RSpec.describe 'api/v1/organizations/:organization_id/tournaments/:tournament_id
     end
   end
 
-  path('/api/v1/organizations/{organization_id}/tournaments/{tournament_id}/players/{id}') do
-    parameter name: :organization_id, in: :path, type: :integer, description: 'ID of the Organization', required: true
+  path('/api/v1/tournaments/{tournament_id}/players/{id}') do
     parameter name: :tournament_id, in: :path, type: :integer, description: 'ID of the Tournament', required: true
 
     get('Show Tournament Player') do


### PR DESCRIPTION
This pull request fixes an issue with the players controller. The `set_organization` method has been removed as it was not being used. The `set_tournament` method has been updated to use the `::Tournament::Tournament` model instead of the `@organization.tournaments` association. The `permitted_params` method has been updated to include the `organization_id` parameter.