### PR TITLE
Remove render.com deploy webhook

### DIFF
--- a/.github/workflows/docker-backend-prod-latest.yml
+++ b/.github/workflows/docker-backend-prod-latest.yml
@@ -49,6 +49,3 @@ jobs:
             thatguyinabeanie/battle-stadium:latest
             ghcr.io/thatguyinabeanie/battle-stadium:latest
 
-      - name: Call render.com deploy webhook
-        run: curl -X POST -d {} ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
-


### PR DESCRIPTION
This pull request removes the render.com deploy webhook from the workflow. The commit "no hook" removes the code that calls the render.com deploy webhook.