### PR TITLE
Fix time hydration error and separate prod base URL

### DIFF
--- a/frontend/components/tournament-table/helpers.tsx
+++ b/frontend/components/tournament-table/helpers.tsx
@@ -1,7 +1,6 @@
 import { Link } from "@nextui-org/react";
 
 import { components } from "@/lib/api";
-import { format, parseISO } from "date-fns";
 
 type Tournament = components["schemas"]["Tournament"];
 
@@ -53,8 +52,16 @@ const renderStartDateString = (start_at: string | null) => {
     return "TBD";
   }
 
-  const startAt = parseISO(start_at);
-  const date = format(startAt, "MMM d, yyyy h:mm a");
+  const startAt = new Date(start_at);
+  const date = startAt.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    hour12: true,
+    timeZone: "UTC",
+  });
 
   return date;
 };

--- a/frontend/lib/api/battle-stadium-api.ts
+++ b/frontend/lib/api/battle-stadium-api.ts
@@ -8,7 +8,7 @@ import { getVercelOidcToken } from "@vercel/functions/oidc";
 
 const getBaseUrl = () => {
   if (process.env.NODE_ENV === "production" && process.env.PROD_API_BASE_URL) {
-    return `${process.env.API_BASE_URL}/api/v1`;
+    return `${process.env.PROD_API_BASE_URL}/api/v1`;
   }
 
   return `http://${process.env.BACKEND_HOST}:10000/api/v1`;

--- a/frontend/lib/api/battle-stadium-api.ts
+++ b/frontend/lib/api/battle-stadium-api.ts
@@ -7,7 +7,7 @@ export type Auth = ReturnType<typeof clerkAuth>;
 import { getVercelOidcToken } from "@vercel/functions/oidc";
 
 const getBaseUrl = () => {
-  if (process.env.NODE_ENV === "production" && process.env.API_BASE_URL) {
+  if (process.env.NODE_ENV === "production" && process.env.PROD_API_BASE_URL) {
     return `${process.env.API_BASE_URL}/api/v1`;
   }
 


### PR DESCRIPTION
This pull request includes two commits. The first commit fixes a time hydration error by updating the code that formats the start date of a tournament. The second commit separates the production base URL by using the `PROD_API_BASE_URL` environment variable instead of `API_BASE_URL`. These changes ensure that the start date is displayed correctly and that the correct base URL is used in the production environment.