### PR TITLE
Add logging for host

### DIFF
--- a/backend/lib/auth/vercel/token_verifier.rb
+++ b/backend/lib/auth/vercel/token_verifier.rb
@@ -5,6 +5,7 @@ require "uri"
 require "json"
 require "jwt"
 
+
 module Auth
   module Vercel
     module TokenVerifier
@@ -13,6 +14,8 @@ module Auth
 
 
       class << self
+        PRODUCTION_HOSTS = ["battlestadium.gg", "www.battlestadium.gg"].freeze
+
         @jwks_cache = nil
 
         def verify(request:)
@@ -24,7 +27,7 @@ module Auth
         def subject_environment(request:)
           Rails.logger.info("Request host: #{request.host}")
           return "development" unless Rails.env.production?
-          return "production" if request.host == "battlestadium.gg"
+          return "production" if PRODUCTION_HOSTS.include?(request.host)
           "preview"
         end
 

--- a/backend/lib/auth/vercel/token_verifier.rb
+++ b/backend/lib/auth/vercel/token_verifier.rb
@@ -28,6 +28,7 @@ module Auth
           Rails.logger.info("Request host: #{request.host}")
           return "development" unless Rails.env.production?
           return "production" if PRODUCTION_HOSTS.include?(request.host)
+          Rails.logger.info("Non-production host detected: #{request.host}")
           "preview"
         end
 

--- a/backend/lib/auth/vercel/token_verifier.rb
+++ b/backend/lib/auth/vercel/token_verifier.rb
@@ -22,9 +22,10 @@ module Auth
         end
 
         def subject_environment(request:)
+          Rails.logger.info("Request host: #{request.host}")
           return "development" unless Rails.env.production?
-          return "preview" if request.host.match?(/battle-stadium-[\w-]+-thatguyinabeanie\.vercel\.app/)
-          "#{ENV['SUBJECT']}:production"
+          return "production" if request.host == "battlestadium.gg"
+          "preview"
         end
 
         def verify_token(token:, request:)

--- a/backend/spec/lib/auth/vercel/token_verifier_spec.rb
+++ b/backend/spec/lib/auth/vercel/token_verifier_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe Auth::Vercel::TokenVerifier do
   let(:request) { instance_double(ActionDispatch::Request, headers: { "X-Vercel-OIDC-Token" => token }, host: "example.com") }
   let(:token) { "valid.jwt.token" }
@@ -35,9 +37,10 @@ RSpec.describe Auth::Vercel::TokenVerifier do
   describe ".subject_environment" do
     context "when in production environment" do
       before { allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production")) }
+      let(:request) { instance_double(ActionDispatch::Request, host: "battlestadium.gg") }
 
       it "returns production subject" do
-        expect(described_class.subject_environment(request:)).to eq("your_subject:production")
+        expect(described_class.subject_environment(request:)).to eq("production")
       end
 
       context "when in preview environment" do


### PR DESCRIPTION
This pull request adds logging for the host in the `subject_environment` method. The `verify` method now logs the request host using the Rails logger. Additionally, the logic for determining the subject environment has been updated. If the request host is "battlestadium.gg", the subject environment is set to "production". Otherwise, it is set to "preview". This change improves the logging and enhances the accuracy of determining the subject environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved environment determination logic for requests, ensuring accurate identification of production and preview environments.
	- Added logging for better tracking of request hosts.

- **Refactor**
	- Simplified control flow in the environment determination method for enhanced clarity and performance.
	- Adjusted expected return value for production environment to streamline output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->