### PR TITLE
Add auto start in production mode

### DIFF
--- a/backend/bin/docker-entrypoint
+++ b/backend/bin/docker-entrypoint
@@ -12,6 +12,13 @@ bundle exec rails db:prepare && \
 echo "== Running migrations ==" && \
 bundle exec rails db:migrate && \
 echo "== Starting server ==" && \
-# bundle exec rails server -b 0.0.0.0 -p $PORT
-sleep infinity
+
+if [ "$RAILS_ENV" = "production" ]; then
+  echo "== Running in production mode =="
+  bundle exec rails server -b 0.0.0.0 -p $PORT
+else
+  echo "== Running in development mode =="
+  sleep infinity
+fi
+
 exec "${@}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     environment:
       RAILS_ENV: development
       PORT: 10000
+      AUTO_START_RAILS: "true"
     build:
       context: backend
       dockerfile: Dockerfile.dev


### PR DESCRIPTION
This pull request adds the ability to automatically start the server in production mode. Previously, the server would only start in development mode. With this change, the server will now start in production mode when the `RAILS_ENV` environment variable is set to "production". This allows for easier deployment and testing in a production environment.