### PR TITLE
Add auto start feature for Rails server

### DIFF
--- a/backend/bin/docker-entrypoint
+++ b/backend/bin/docker-entrypoint
@@ -12,6 +12,13 @@ bundle exec rails db:prepare && \
 echo "== Running migrations ==" && \
 bundle exec rails db:migrate && \
 echo "== Starting server ==" && \
-# bundle exec rails server -b 0.0.0.0 -p $PORT
-sleep infinity
+
+if [ "$RAILS_ENV" = "production" ]; then
+  echo "== Running in production mode =="
+  bundle exec rails server -b 0.0.0.0 -p $PORT
+else
+  echo "== Running in development mode =="
+  sleep infinity
+fi
+
 exec "${@}"

--- a/backend/bin/docker-entrypoint
+++ b/backend/bin/docker-entrypoint
@@ -13,7 +13,7 @@ echo "== Running migrations ==" && \
 bundle exec rails db:migrate && \
 echo "== Starting server ==" && \
 
-if [ "$RAILS_ENV" = "production" ]; then
+if [ "$RAILS_ENV" = "production" ] || [ "$AUTO_START_RAILS" = "true" ]; then
   echo "== Running in production mode =="
   bundle exec rails server -b 0.0.0.0 -p $PORT
 else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     environment:
       RAILS_ENV: development
       PORT: 10000
+      AUTO_START_RAILS: "true"
     build:
       context: backend
       dockerfile: Dockerfile.dev


### PR DESCRIPTION
This pull request adds the ability to automatically start the Rails server in production mode or in development mode if the `AUTO_START_RAILS` environment variable is set to "true". Previously, the server would only start in development mode. This change allows for easier deployment and testing of the application.