### PR TITLE
Refactor connection and authorization logic

### DIFF
--- a/backend/app/channels/application_cable/connection.rb
+++ b/backend/app/channels/application_cable/connection.rb
@@ -16,8 +16,10 @@ module ApplicationCable
       verified_user = User.find_by(id: clerk_user&.user_id)
 
       if verified_user
+        Rails.logger.info "User #{verified_user.id} connected"
         verified_user
       else
+        Rails.logger.info "User not found - clerk id: #{clerk_user_id} - user id: #{clerk_user&.user_id}"
         reject_unauthorized_connection
       end
     end

--- a/backend/app/channels/chat_channel.rb
+++ b/backend/app/channels/chat_channel.rb
@@ -79,6 +79,8 @@ class ChatChannel < ApplicationCable::Channel
   end
 
   def authorized_to_join?(match:)
+    return true if current_user.admin?
+
     return false unless match.present? && match.round.present? && match.round.ended_at.nil?
 
     authorize match, :join_chat?

--- a/backend/app/channels/chat_channel.rb
+++ b/backend/app/channels/chat_channel.rb
@@ -1,5 +1,6 @@
 # app/channels/chat_channel.rb
 class ChatChannel < ApplicationCable::Channel
+  include Pundit::Authorization
   attr_reader :subscription_data
 
   MAX_MESSAGE_SIZE = 1.megabyte
@@ -80,7 +81,7 @@ class ChatChannel < ApplicationCable::Channel
   def authorized_to_join?(match:)
     return false unless match.present? && match.round.present? && match.round.ended_at.nil?
 
-    match.can_access?(user: current_user)
+    authorize match, :join_chat?
   end
 
   def load_previous_messages(match_id:)

--- a/backend/app/models/tournaments/match.rb
+++ b/backend/app/models/tournaments/match.rb
@@ -46,9 +46,5 @@ module Tournaments
         raise ArgumentError, "Cannot check in a player that is not part of the match."
       end
     end
-
-    def can_access?(user:)
-      [player_one, player_two].any? { |player| player.user == user } || organization.has_staff_member?(user:)
-    end
   end
 end

--- a/backend/app/policies/organization_policy.rb
+++ b/backend/app/policies/organization_policy.rb
@@ -1,22 +1,34 @@
 class OrganizationPolicy < ApplicationPolicy
+  def owner?
+    record.owner == user
+  end
+
+  def admin?
+    super || owner?
+  end
+
+  def create?
+    user&.admin?
+  end
+
   def update?
-    super || record.owner == user
+    super || admin?
   end
 
   def staff?
-    true
+    admin? || record.has_staff_member?(user:)
   end
 
   def add_staff?
-    user.admin? || record.owner == user
+    admin?
   end
 
   def remove_staff?
-    user.admin? || record.owner == user
+    admin?|| owner?
   end
 
   def create_tournament?
-    user.admin? || record.owner == user || record.staff_members.include?(user)
+    admin? || record.has_staff_member?(user:)
   end
 
   def update_tournament?
@@ -32,6 +44,6 @@ class OrganizationPolicy < ApplicationPolicy
   end
 
   def delete_tournament?
-    user.admin? || record.owner == user
+    admin?
   end
 end

--- a/backend/app/policies/tournaments/match_policy.rb
+++ b/backend/app/policies/tournaments/match_policy.rb
@@ -1,0 +1,28 @@
+module Tournaments
+  class MatchPolicy < ApplicationPolicy
+    def show?
+      admin? || Pundit.policy(user, record.tournament).show?
+    end
+    def create?
+      admin? || Pundit.policy(user, record.tournament).update?
+    end
+
+    def update?
+      admin? || Pundit.policy(user, record.tournament).update?
+    end
+
+    def destroy?
+      admin? || Pundit.policy(user, record.tournament).update?
+    end
+
+    def join_chat?
+      admin? || Pundit.policy(user, record.tournament.organization).staff? || is_match_player?
+    end
+
+    private
+
+    def is_match_player?
+      [record.player_one, record.player_two].any? { |player| player.user == user }
+    end
+  end
+end


### PR DESCRIPTION
This pull request includes several commits that refactor the connection and authorization logic in the codebase. The `connection.rb` file has been refactored to log user connection information, and the `chat_channel.rb` file now includes the `Pundit::Authorization` module. The `match.rb` file has had the unused `can_access?` method removed, and the `chat_channel.rb` file now uses the `authorize` method instead of `match.can_access?`. Additionally, the `organization_policy.rb` file has been updated to use the `owner?` and `admin?` methods, and a new `match_policy.rb` file has been added to handle match-related authorization. These changes improve the clarity and maintainability of the codebase.