### PR TITLE
Fix authorization header names

### DIFF
--- a/backend/lib/auth/clerk/token_verifier.rb
+++ b/backend/lib/auth/clerk/token_verifier.rb
@@ -18,7 +18,7 @@ module Auth
         def verify(request:)
           session_token = request.headers["Authorization"]&.split("Bearer ")&.last
 
-          raise NoAuthorizationHeader, "Authorization header missing or malformed"  unless session_token
+          raise NoAuthorizationHeader, "Clerk Authorization header missing or malformed"  unless session_token
 
           verify_token(session_token:)
         end

--- a/backend/lib/auth/vercel/token_verifier.rb
+++ b/backend/lib/auth/vercel/token_verifier.rb
@@ -17,7 +17,7 @@ module Auth
 
         def verify(request:)
           token = request.headers["X-Vercel-OIDC-Token"]
-          raise NoAuthorizationHeader, "Authorization header missing or malformed" unless token
+          raise NoAuthorizationHeader, "X-Vercel-OIDC-Token Header missing or malformed" unless token
           verify_token(token:, request:)
         end
 


### PR DESCRIPTION
The pull request fixes the authorization header names in two different classes. In the first commit, the "Authorization" header is changed to "Clerk Authorization" header. In the second commit, the "Authorization" header is changed to "X-Vercel-OIDC-Token" header. This ensures that the correct headers are used for authorization in both cases.