### PR TITLE
fix migration

### DIFF
--- a/backend/db/migrate/20241004230537_rename_reported_at_to_ended_at_in_matches.rb
+++ b/backend/db/migrate/20241004230537_rename_reported_at_to_ended_at_in_matches.rb
@@ -1,6 +1,6 @@
 class RenameReportedAtToEndedAtInMatches < ActiveRecord::Migration[7.2]
   def change
-    rename_column :matches, :ended_at, :ended_at
-    rename_column :match_games, :ended_at, :ended_at
+    rename_column :matches, :reported_at, :ended_at
+    rename_column :match_games, :reported_at, :ended_at
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the column names in the database for better clarity: `reported_at` is now consistently renamed to `ended_at` in both the `matches` and `match_games` tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->