### PR TITLE
Update generated API

### DIFF
--- a/backend/openapi/v1/openapi.yaml
+++ b/backend/openapi/v1/openapi.yaml
@@ -750,6 +750,17 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Profile"
+        '404':
+          description: profile not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                - error
   "/tournaments/{tournament_id}/matches":
     parameters:
     - name: X-Vercel-OIDC-Token
@@ -809,7 +820,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Match"
+                "$ref": "#/components/schemas/MatchDetails"
         '404':
           description: match not found
     patch:
@@ -887,7 +898,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Match"
+                "$ref": "#/components/schemas/MatchDetails"
   "/tournaments/{tournament_id}/matches/{id}/reset":
     parameters:
     - name: X-Vercel-OIDC-Token
@@ -920,7 +931,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/Match"
+                "$ref": "#/components/schemas/MatchDetails"
   "/tournaments/{tournament_id}/phases":
     parameters:
     - name: tournament_id
@@ -2252,3 +2263,64 @@ components:
       - player_one
       - player_two
       - reset_by
+    MatchDetails:
+      type: object
+      title: Match
+      properties:
+        id:
+          type: integer
+          format: int64
+        round_id:
+          type: integer
+          format: int64
+        tournament_id:
+          type: integer
+          format: int64
+        table_number:
+          type: integer
+          format: int64
+        player_one:
+          type: string
+        player_two:
+          type: string
+        reset_by:
+          type: string
+          nullable: true
+        winner:
+          type: string
+          nullable: true
+        loser:
+          type: string
+          nullable: true
+        player_one_check_in:
+          type: string
+          format: date-time
+          nullable: true
+        player_two_check_in:
+          type: string
+          format: date-time
+          nullable: true
+        ended_at:
+          type: string
+          format: date-time
+          nullable: true
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        bye:
+          type: boolean
+      required:
+      - id
+      - round_id
+      - table_number
+      - player_one
+      - player_two
+      - reset_by
+      - winner
+      - loser
+      - player_one_check_in
+      - player_two_check_in
+      - ended_at
+      - started_at
+      - bye

--- a/frontend/lib/api/openapi-v1.d.ts
+++ b/frontend/lib/api/openapi-v1.d.ts
@@ -416,7 +416,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            "application/json": components["schemas"]["Match"];
+            "application/json": components["schemas"]["MatchDetails"];
           };
         };
         /** @description match not found */
@@ -527,7 +527,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            "application/json": components["schemas"]["Match"];
+            "application/json": components["schemas"]["MatchDetails"];
           };
         };
       };
@@ -579,7 +579,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            "application/json": components["schemas"]["Match"];
+            "application/json": components["schemas"]["MatchDetails"];
           };
         };
       };
@@ -1165,6 +1165,31 @@ export interface components {
       player_one: string;
       player_two: string;
       reset_by: string | null;
+    };
+    /** Match */
+    MatchDetails: {
+      /** Format: int64 */
+      id: number;
+      /** Format: int64 */
+      round_id: number;
+      /** Format: int64 */
+      tournament_id?: number;
+      /** Format: int64 */
+      table_number: number;
+      player_one: string;
+      player_two: string;
+      reset_by: string | null;
+      winner: string | null;
+      loser: string | null;
+      /** Format: date-time */
+      player_one_check_in: string | null;
+      /** Format: date-time */
+      player_two_check_in: string | null;
+      /** Format: date-time */
+      ended_at: string | null;
+      /** Format: date-time */
+      started_at: string | null;
+      bye: boolean;
     };
   };
   responses: {
@@ -2033,6 +2058,17 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["Profile"];
+        };
+      };
+      /** @description profile not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
         };
       };
     };


### PR DESCRIPTION
This pull request updates the generated API to include a new response for the '404' status code in the '/profiles/{id}' endpoint. The response now includes an 'error' property in the JSON schema. Additionally, the 'Match' schema has been renamed to 'MatchDetails' and includes new properties such as 'winner', 'loser', 'player_one_check_in', 'player_two_check_in', 'ended_at', 'started_at', and 'bye'.