### PR TITLE
Refactor ProfilesController and ProfilePolicy

### DIFF
--- a/backend/app/policies/profile_policy.rb
+++ b/backend/app/policies/profile_policy.rb
@@ -1,6 +1,6 @@
 class ProfilePolicy < ApplicationPolicy
   def show?
-    (record.archived_at.nil?) || account == record.account || account.admin?
+    record.archived_at.nil? || account == record.account || account.admin?
   end
 
   def create_pokemon_team?

--- a/frontend/app/dashboard/@profiles/page.tsx
+++ b/frontend/app/dashboard/@profiles/page.tsx
@@ -1,7 +1,4 @@
-import { get } from "http";
-
 export default function Profiles() {
-
   return (
     <div>
       <h1>Profiles</h1>

--- a/frontend/app/dashboard/@profiles/page.tsx
+++ b/frontend/app/dashboard/@profiles/page.tsx
@@ -1,4 +1,7 @@
+import { get } from "http";
+
 export default function Profiles() {
+
   return (
     <div>
       <h1>Profiles</h1>


### PR DESCRIPTION
This pull request includes refactoring of the ProfilesController and ProfilePolicy classes. In the ProfilesController, the index action has been updated to handle different scenarios based on the presence of the account_id parameter. The logic now checks if the current account matches the requested account and returns the corresponding profiles. In the ProfilePolicy, the show? method has been simplified to check if the profile is archived, if the current account matches the profile's account, or if the current account is an admin. These changes improve the readability and maintainability of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced authorization for profile access based on account context.
	- Added support for filtering profiles by `account_id` in the profiles endpoint.

- **Bug Fixes**
	- Improved logic for retrieving profiles to ensure only relevant, unarchived profiles are returned based on the provided account ID.

- **Tests**
	- Expanded test scenarios for the profiles endpoint to cover new filtering capabilities and clarify response descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->