### PR TITLE
Add support for RK9 profiles

### DIFF
--- a/backend/app/controllers/api/v1/pokemon_teams_controller.rb
+++ b/backend/app/controllers/api/v1/pokemon_teams_controller.rb
@@ -20,7 +20,7 @@ module Api
                     end
                   rescue ActiveRecord::RecordNotFound
                     skip_authorization
-                    return render json: { error: "Profile not found" }, status: :not_found
+                    return render json: { error: "Battle Stadium Profile not found" }, status: :not_found
                   end
 
         authorize profile, :create_pokemon_team?

--- a/backend/app/controllers/api/v1/tournaments_controller.rb
+++ b/backend/app/controllers/api/v1/tournaments_controller.rb
@@ -28,7 +28,6 @@ module Api
       end
 
       def show
-
         @object = @tournament
         super
         authorize @tournament, :show?

--- a/backend/app/models/abstract_profile.rb
+++ b/backend/app/models/abstract_profile.rb
@@ -1,0 +1,33 @@
+# backend/app/models/profile.rb
+class AbstractProfile < ApplicationRecord
+  extend FriendlyId
+
+  self.table_name = "profiles"
+  self.inheritance_column = "type"
+
+  friendly_id :username, use: :slugged
+
+  belongs_to :account, class_name: "Account", inverse_of: :profiles, optional: true, foreign_key: "account_id"
+  has_many :players, class_name: "Tournaments::Player", inverse_of: :profile, foreign_key: "profile_id"
+  has_many :pokemon_teams, class_name: "PokemonTeam", inverse_of: :profile, foreign_key: "profile_id"
+
+  validates :username, presence: true, uniqueness: true
+  validates :default, inclusion: { in: [true, false] }
+  validate :only_one_default_profile_per_account
+
+  delegate :pronouns, to: :account
+
+  scope :not_archived, -> { where(archived_at: nil) }
+
+  def should_generate_new_friendly_id?
+    username_changed?
+  end
+
+  private
+
+  def only_one_default_profile_per_account
+    if default && account.profiles.where(default: true).where.not(id:).exists?
+      errors.add(:default, "can only be set to true for one profile per account")
+    end
+  end
+end

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -22,7 +22,7 @@ class Account < ApplicationRecord
   has_one :default_profile, class_name: "Profile", dependent: :destroy, inverse_of: :account
   has_one :rk9_profile, class_name: "Rk9Profile", inverse_of: :account, foreign_key: "account_id", dependent: :nullify
 
-  has_many :profiles, ->(account) { where(account: account.id ).order(id: :asc) }, class_name: "Profile", dependent: :nullify, inverse_of: :account
+  has_many :profiles, ->(account) { where(account: account.id).order(id: :asc) }, class_name: "Profile", dependent: :nullify, inverse_of: :account
 
   def staff_member_of?(organization)
     organization.staff.exists?(id:) || organization.owner == self

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -20,7 +20,9 @@ class Account < ApplicationRecord
 
   after_create :create_default_profile
   has_one :default_profile, class_name: "Profile", dependent: :destroy, inverse_of: :account
-  has_many :profiles, ->(account) { where(account: account.id).order(id: :asc) }, class_name: "Profile", dependent: :destroy, inverse_of: :account
+  has_one :rk9_profile, class_name: "Rk9Profile", inverse_of: :account, foreign_key: "account_id", dependent: :nullify
+
+  has_many :profiles, ->(account) { where(account: account.id ).order(id: :asc) }, class_name: "Profile", dependent: :nullify, inverse_of: :account
 
   def staff_member_of?(organization)
     organization.staff.exists?(id:) || organization.owner == self

--- a/backend/app/models/profile.rb
+++ b/backend/app/models/profile.rb
@@ -1,32 +1,3 @@
+class Profile < AbstractProfile
 
-class Profile < ApplicationRecord
-  self.table_name = "profiles"
-  extend FriendlyId
-  friendly_id :username, use: :slugged
-
-  belongs_to :account, class_name: "Account", inverse_of: :profiles, optional: true, foreign_key: "account_id"
-
-
-  has_many :players, class_name: "Tournaments::Player", inverse_of: :profile, foreign_key: "profile_id"
-  has_many :pokemon_teams, class_name: "PokemonTeam", inverse_of: :profile, foreign_key: "profile_id"
-
-  validates :username, presence: true, uniqueness: true
-  validates :default, inclusion: { in: [true, false] }
-  validate :only_one_default_profile_per_account
-
-  delegate :pronouns, to: :account
-
-  scope :not_archived, -> { where(archived_at: nil) }
-
-  def should_generate_new_friendly_id?
-    username_changed?
-  end
-
-  private
-
-  def only_one_default_profile_per_account
-    if default && account.profiles.where(default: true).where.not(id:).exists?
-      errors.add(:default, "can only be set to true for one profile per account")
-    end
-  end
 end

--- a/backend/app/models/rk9_profile.rb
+++ b/backend/app/models/rk9_profile.rb
@@ -1,0 +1,3 @@
+class Rk9Profile < AbstractProfile
+
+end

--- a/backend/app/models/rk9_tournament.rb
+++ b/backend/app/models/rk9_tournament.rb
@@ -1,5 +1,5 @@
 class Rk9Tournament < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   validates :start_date, presence: true
   validates :end_date, presence: true
   validates :rk9_id, presence: true, uniqueness: true

--- a/backend/app/models/rk9_tournament.rb
+++ b/backend/app/models/rk9_tournament.rb
@@ -1,0 +1,6 @@
+class Rk9Tournament < ApplicationRecord
+  validates :name, presence: true
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+  validates :rk9_id, presence: true, uniqueness: true
+end

--- a/backend/app/models/rk9_tournament.rb
+++ b/backend/app/models/rk9_tournament.rb
@@ -3,4 +3,32 @@ class Rk9Tournament < ApplicationRecord
   validates :start_date, presence: true
   validates :end_date, presence: true
   validates :rk9_id, presence: true, uniqueness: true
+
+  validate :start_date_before_end_date
+  has_many :rk9_profiles
+
+  scope :active, -> { where('start_date <= ? AND end_date >= ?', Date.today, Date.today) }
+  scope :upcoming, -> { where('start_date > ?', Date.today) }
+  scope :past, -> { where('end_date < ?', Date.today) }
+
+  def active?
+    start_date <= Date.today && end_date >= Date.today
+  end
+
+  def upcoming?
+    start_date > Date.today
+  end
+
+  def past?
+    end_date < Date.today
+  end
+  private
+
+  def start_date_before_end_date
+    return if start_date.blank? || end_date.blank?
+
+    if start_date > end_date
+      errors.add(:start_date, "must be before end date")
+    end
+  end
 end

--- a/backend/app/models/tournaments/player.rb
+++ b/backend/app/models/tournaments/player.rb
@@ -2,7 +2,7 @@ module Tournaments
   class Player < ApplicationRecord
     MAX_POKEMON_SUBMISSIONS = 6
     self.table_name = "players"
-    belongs_to :account, class_name: "Account", optional: false, validate: true
+    belongs_to :account, class_name: "Account", optional: true, validate: true
     belongs_to :profile, class_name: "Profile", inverse_of: :players, optional: false, validate: true
     belongs_to :tournament, class_name: "Tournaments::Tournament", inverse_of: :players, optional: false, validate: true
     belongs_to :pokemon_team, class_name: "PokemonTeam", optional: true

--- a/backend/db/migrate/20241026233312_add_type_to_profiles.rb
+++ b/backend/db/migrate/20241026233312_add_type_to_profiles.rb
@@ -1,5 +1,5 @@
 class AddTypeToProfiles < ActiveRecord::Migration[7.2]
   def change
-    add_column :profiles, :type, :string
+    add_column :profiles, :type, :string, null: false, default: "Profile"
   end
 end

--- a/backend/db/migrate/20241026233312_add_type_to_profiles.rb
+++ b/backend/db/migrate/20241026233312_add_type_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddTypeToProfiles < ActiveRecord::Migration[7.2]
+  def change
+    add_column :profiles, :type, :string
+  end
+end

--- a/backend/db/migrate/20241027005305_create_rk9_tournaments.rb
+++ b/backend/db/migrate/20241027005305_create_rk9_tournaments.rb
@@ -1,0 +1,14 @@
+class CreateRk9Tournaments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :rk9_tournaments do |t|
+      t.string :rk9_id, null: false
+      t.string :name, null: false
+      t.date :start_date, null: false
+      t.date :end_date, null: false
+
+      t.timestamps
+    end
+
+    add_index :rk9_tournaments, :rk9_id, unique: true
+  end
+end

--- a/backend/db/migrate/20241027005305_create_rk9_tournaments.rb
+++ b/backend/db/migrate/20241027005305_create_rk9_tournaments.rb
@@ -10,5 +10,9 @@ class CreateRk9Tournaments < ActiveRecord::Migration[7.2]
     end
 
     add_index :rk9_tournaments, :rk9_id, unique: true
+    add_index :rk9_tournaments, :start_date
+    add_index :rk9_tournaments, :end_date
+    add_index :rk9_tournaments, %i[start_date end_date], name: "index_rk9_tournaments_on_start_and_end_date"
+    add_index :rk9_tournaments, :name, unique: true
   end
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -252,7 +252,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_27_005305) do
     t.datetime "archived_at"
     t.bigint "account_id"
     t.boolean "default", default: false, null: false
-    t.string "type"
+    t.string "type", default: "Profile", null: false
     t.index ["account_id"], name: "index_profiles_on_account_id"
     t.index ["slug"], name: "index_profiles_on_slug", unique: true
     t.index ["username"], name: "index_profiles_on_username", unique: true

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_26_233312) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_27_005305) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -256,6 +256,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_26_233312) do
     t.index ["account_id"], name: "index_profiles_on_account_id"
     t.index ["slug"], name: "index_profiles_on_slug", unique: true
     t.index ["username"], name: "index_profiles_on_username", unique: true
+  end
+
+  create_table "rk9_tournaments", force: :cascade do |t|
+    t.string "rk9_id", null: false
+    t.string "name", null: false
+    t.date "start_date", null: false
+    t.date "end_date", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["rk9_id"], name: "index_rk9_tournaments_on_rk9_id", unique: true
   end
 
   create_table "rounds", force: :cascade do |t|

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -265,7 +265,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_27_005305) do
     t.date "end_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["end_date"], name: "index_rk9_tournaments_on_end_date"
+    t.index ["name"], name: "index_rk9_tournaments_on_name", unique: true
     t.index ["rk9_id"], name: "index_rk9_tournaments_on_rk9_id", unique: true
+    t.index ["start_date", "end_date"], name: "index_rk9_tournaments_on_start_and_end_date"
+    t.index ["start_date"], name: "index_rk9_tournaments_on_start_date"
   end
 
   create_table "rounds", force: :cascade do |t|

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_20_150304) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_26_233312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -252,6 +252,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_20_150304) do
     t.datetime "archived_at"
     t.bigint "account_id"
     t.boolean "default", default: false, null: false
+    t.string "type"
     t.index ["account_id"], name: "index_profiles_on_account_id"
     t.index ["slug"], name: "index_profiles_on_slug", unique: true
     t.index ["username"], name: "index_profiles_on_username", unique: true

--- a/backend/lib/tasks/limitless.rake
+++ b/backend/lib/tasks/limitless.rake
@@ -104,6 +104,7 @@ namespace :limitless do
             tour.game_id = tournament_data['bs_game_id']
             tour.format_id = tournament_data['bs_format_id']
             tour.check_in_start_at = tour.start_at - 1.hour
+            tour.published = true
           end
         rescue StandardError => e
           errors << {

--- a/backend/spec/models/account_spec.rb
+++ b/backend/spec/models/account_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Account do
   let(:username) { Faker::Internet.unique.username }
 
   describe "associations" do
+    it { is_expected.to have_one(:rk9_profile).class_name("Rk9Profile").inverse_of(:account).with_foreign_key("account_id").dependent(:nullify) }
     it { is_expected.to have_one(:default_profile).class_name("Profile").dependent(:destroy).inverse_of(:account) }
-    it { is_expected.to have_many(:profiles).class_name("Profile").dependent(:destroy).inverse_of(:account) }
+    it { is_expected.to have_many(:profiles).class_name("Profile").dependent(:nullify).inverse_of(:account) }
     it { is_expected.to have_one(:owned_organization).class_name("Organization").with_foreign_key("owner_id").dependent(:destroy).inverse_of(:owner) }
     it { is_expected.to have_many(:organization_staff_members).class_name("OrganizationStaffMember").dependent(:destroy) }
     it { is_expected.to have_many(:staff).through(:organization_staff_members).source(:account) }

--- a/backend/spec/models/rk9_tournament_spec.rb
+++ b/backend/spec/models/rk9_tournament_spec.rb
@@ -1,37 +1,96 @@
-
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Rk9Tournament, type: :model do
-  subject { described_class.new(name: "Tournament Name", start_date: Date.today, end_date: Date.today + 1, rk9_id: "12345") }
+  let(:tournament) { described_class.new(rk9_id: "NA02mtILnc5ycfC7jXkD", name: "North America Pokémon VGC International Championship 2024", start_date: Date.today, end_date: Date.today + 2) }
 
   describe "validations" do
     it "is valid with valid attributes" do
-      expect(subject).to be_valid
-    end
-
-    it "is not valid without a name" do
-      subject.name = nil
-      expect(subject).to_not be_valid
-    end
-
-    it "is not valid without a start_date" do
-      subject.start_date = nil
-      expect(subject).to_not be_valid
-    end
-
-    it "is not valid without an end_date" do
-      subject.end_date = nil
-      expect(subject).to_not be_valid
+      expect(tournament).to be_valid
     end
 
     it "is not valid without an rk9_id" do
-      subject.rk9_id = nil
-      expect(subject).to_not be_valid
+      tournament.rk9_id = nil
+      expect(tournament).not_to be_valid
     end
 
-    it "is not valid with a duplicate rk9_id" do
-      described_class.create!(name: "Another Tournament", start_date: Date.today, end_date: Date.today + 1, rk9_id: "12345")
-      expect(subject).to_not be_valid
+    it "is not valid without a name" do
+      tournament.name = nil
+      expect(tournament).not_to be_valid
+    end
+
+    it "is not valid without a start_date" do
+      tournament.start_date = nil
+      expect(tournament).not_to be_valid
+    end
+
+    it "is not valid without an end_date" do
+      tournament.end_date = nil
+      expect(tournament).not_to be_valid
+    end
+
+    it "is valid if start_date is the same as end_date" do
+      tournament.start_date = Date.today
+      tournament.end_date = Date.today
+      expect(tournament).to be_valid
+    end
+  end
+
+  describe "scopes" do
+    let!(:active_tournament) { described_class.create!(name: "Active Tournament", start_date: Date.today - 1, end_date: Date.today + 1, rk9_id: "active123") }
+    let!(:upcoming_tournament) { described_class.create!(name: "Upcoming Tournament", start_date: Date.today + 1, end_date: Date.today + 2, rk9_id: "upcoming123") }
+    let!(:past_tournament) { described_class.create!(name: "Past Tournament", start_date: Date.today - 3, end_date: Date.today - 1, rk9_id: "past123") }
+
+    it "returns active tournaments" do
+      expect(described_class.active).to include(active_tournament)
+      expect(described_class.active).not_to include(upcoming_tournament, past_tournament)
+    end
+
+    it "returns upcoming tournaments" do
+      expect(described_class.upcoming).to include(upcoming_tournament)
+      expect(described_class.upcoming).not_to include(active_tournament, past_tournament)
+    end
+
+    it "returns past tournaments" do
+      expect(described_class.past).to include(past_tournament)
+      expect(described_class.past).not_to include(active_tournament, upcoming_tournament)
+    end
+  end
+
+  describe "status methods" do
+    it "returns true for active? if the tournament is currently active" do
+      tournament.start_date = Date.today - 1
+      tournament.end_date = Date.today + 1
+      expect(tournament.active?).to be true
+    end
+
+    it "returns false for active? if the tournament is not currently active" do
+      tournament.start_date = Date.today + 1
+      tournament.end_date = Date.today + 2
+      expect(tournament.active?).to be false
+    end
+
+    it "returns true for upcoming? if the tournament is upcoming" do
+      tournament.start_date = Date.today + 1
+      tournament.end_date = Date.today + 2
+      expect(tournament.upcoming?).to be true
+    end
+
+    it "returns false for upcoming? if the tournament is not upcoming" do
+      tournament.start_date = Date.today - 1
+      tournament.end_date = Date.today + 1
+      expect(tournament.upcoming?).to be false
+    end
+
+    it "returns true for past? if the tournament is past" do
+      tournament.start_date = Date.today - 3
+      tournament.end_date = Date.today - 1
+      expect(tournament.past?).to be true
+    end
+
+    it "returns false for past? if the tournament is not past" do
+      tournament.start_date = Date.today + 1
+      tournament.end_date = Date.today + 2
+      expect(tournament.past?).to be false
     end
   end
 end

--- a/backend/spec/models/rk9_tournament_spec.rb
+++ b/backend/spec/models/rk9_tournament_spec.rb
@@ -1,0 +1,37 @@
+
+require "rails_helper"
+
+RSpec.describe Rk9Tournament, type: :model do
+  subject { described_class.new(name: "Tournament Name", start_date: Date.today, end_date: Date.today + 1, rk9_id: "12345") }
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(subject).to be_valid
+    end
+
+    it "is not valid without a name" do
+      subject.name = nil
+      expect(subject).to_not be_valid
+    end
+
+    it "is not valid without a start_date" do
+      subject.start_date = nil
+      expect(subject).to_not be_valid
+    end
+
+    it "is not valid without an end_date" do
+      subject.end_date = nil
+      expect(subject).to_not be_valid
+    end
+
+    it "is not valid without an rk9_id" do
+      subject.rk9_id = nil
+      expect(subject).to_not be_valid
+    end
+
+    it "is not valid with a duplicate rk9_id" do
+      described_class.create!(name: "Another Tournament", start_date: Date.today, end_date: Date.today + 1, rk9_id: "12345")
+      expect(subject).to_not be_valid
+    end
+  end
+end

--- a/backend/spec/models/rk9_tournament_spec.rb
+++ b/backend/spec/models/rk9_tournament_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Rk9Tournament, type: :model do
-  let(:tournament) { described_class.new(rk9_id: "NA02mtILnc5ycfC7jXkD", name: "North America Pokémon VGC International Championship 2024", start_date: Date.today, end_date: Date.today + 2) }
+  let(:tournament) {  described_class.new(name: "Tournament Name", start_date: Date.new(2024, 1, 1), end_date: Date.new(2024, 1, 2), rk9_id: "12345") }
 
   describe "validations" do
     it "is valid with valid attributes" do

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -55,7 +55,7 @@ export default async function RootLayout({ children }: ChildrenProps & AppProps)
             <Providers>
               <div className="flex flex-col items-center min-h-svh">
                 <AwesomeParticles />
-                <div className="flex flex-col items-center min-h-screen backdrop-blur-lg shadow-2xl shadow-white w-4/5 ">
+                <div className="flex flex-col items-center min-h-screen backdrop-blur-lg shadow-2xl shadow-white w-5/6 ">
                   <NavigationBar />
 
                   <main className="flex flex-col items-center min-h-screen w-full">

--- a/frontend/components/awesome-particles.tsx
+++ b/frontend/components/awesome-particles.tsx
@@ -53,7 +53,7 @@ const useAwesomeParticlesOptions = (): ISourceOptions => {
         direction: MoveDirection.none,
         enable: true,
         random: true,
-        speed: 3,
+        speed: 1,
         straight: false,
       },
       number: {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -34,7 +34,7 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "limitlesstcg.s3.us-east-2.amazonaws.com",
       },
-    ]
+    ],
   },
   reactStrictMode: true,
 };

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -8,6 +8,7 @@ dotenv.config({ path: join(process.cwd(), ".env.development.local") });
 
 const nextConfig: NextConfig = {
   experimental: {
+    // ppr: 'incremental',
     after: true,
     cssChunking: "loose", // default
     // how many times Next.js will retry failed page generation attempts

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -20,6 +20,22 @@ const nextConfig: NextConfig = {
   },
   expireTime: 3600,
 
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "pokepast.es",
+      },
+      {
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
+      },
+      {
+        protocol: "https",
+        hostname: "limitlesstcg.s3.us-east-2.amazonaws.com",
+      },
+    ]
+  },
   reactStrictMode: true,
 };
 


### PR DESCRIPTION
This pull request adds support for RK9 profiles. It includes changes to the `Profile` model, adding a new `AbstractProfile` class and a new `Rk9Profile` class. The `Account` model now has a `rk9_profile` association. Additionally, there are some minor changes to the `Player` model and the database schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced error messaging for missing profiles in the Pokémon team creation process.
  - Tournaments now automatically marked as published upon creation or update.
  - New profile types introduced with the addition of `AbstractProfile` and `Rk9Profile`.
  - New `Rk9Tournament` model added with validations for tournament attributes.

- **Bug Fixes**
  - Improved error handling for missing parameters in tournament creation.

- **Documentation**
  - Updated tests for account associations to reflect new profile relationships.

- **Refactor**
  - Streamlined tournament and organization retrieval logic in the controller.

- **Configuration**
  - Added remote image sources for fetching images in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->