### PR TITLE
add sidekiq render worker

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -48,6 +48,8 @@ gem "uri", "~> 0.13.1"
 
 # Redis
 gem "redis", "~> 5"
+gem "redis-namespace"
+gem "redis-rails"
 
 # Development Tools
 gem "rb-readline"

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -39,6 +39,7 @@ gem "rack-cors", "~> 2"
 
 # Utilities
 gem "awesome_print"
+gem "dotenv-rails"
 gem "ostruct", "~> 0"
 gem "parallel", "~> 1.26"
 gem "retries"
@@ -82,7 +83,6 @@ end
 
 group :development, :test do
   gem "debug", "~> 1"
-  gem "dotenv-rails"
   gem "faker", "~> 3"
   gem "listen", "~> 3.3"
   gem "parallel_tests", "~> 4"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.16.7-arm-linux)
@@ -342,7 +342,7 @@ GEM
       rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.3)
+    rubocop-ast (1.33.0)
       parser (>= 3.3.1.0)
     rubocop-checkstyle_formatter (0.6.0)
       rubocop (>= 1.14.0)
@@ -442,7 +442,7 @@ GEM
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
-    sorbet-runtime (0.5.11618)
+    sorbet-runtime (0.5.11620)
     spring (4.2.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -294,8 +294,26 @@ GEM
       psych (>= 4.0.0)
     redis (5.3.0)
       redis-client (>= 0.22.0)
+    redis-actionpack (5.4.0)
+      actionpack (>= 5, < 8)
+      redis-rack (>= 2.1.0, < 4)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.3.0)
+      activesupport (>= 3, < 8)
+      redis-store (>= 1.3, < 2)
     redis-client (0.22.2)
       connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    redis-rack (3.0.0)
+      rack-session (>= 0.2.0)
+      redis-store (>= 1.2, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.11.0)
+      redis (>= 4, < 6)
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
@@ -542,6 +560,8 @@ DEPENDENCIES
   rails-erd
   rb-readline
   redis (~> 5)
+  redis-namespace
+  redis-rails
   retries
   rspec-json_expectations
   rspec-rails

--- a/backend/app/jobs/save_chat_message_job.rb
+++ b/backend/app/jobs/save_chat_message_job.rb
@@ -2,16 +2,13 @@ class SaveChatMessageJob < ApplicationJob
   queue_as :default
 
   def perform(match_id:, profile_id:, content:, account_id:, sent_at:, message_type:)
-
-
-    Rails.logger.info("HELLO WORLD")
-    # ChatMessage.create!(
-    #   match_id:,
-    #   account_id:,
-    #   profile_id:,
-    #   content:,
-    #   message_type:,
-    #   sent_at:
-    # )
+    ChatMessage.create!(
+      match_id:,
+      account_id:,
+      profile_id:,
+      content:,
+      message_type:,
+      sent_at:
+    )
   end
 end

--- a/backend/app/jobs/save_chat_message_job.rb
+++ b/backend/app/jobs/save_chat_message_job.rb
@@ -3,13 +3,15 @@ class SaveChatMessageJob < ApplicationJob
 
   def perform(match_id:, profile_id:, content:, account_id:, sent_at:, message_type:)
 
-    ChatMessage.create!(
-      match_id:,
-      account_id:,
-      profile_id:,
-      content:,
-      message_type:,
-      sent_at:
-    )
+
+    Rails.logger.info("HELLO WORLD")
+    # ChatMessage.create!(
+    #   match_id:,
+    #   account_id:,
+    #   profile_id:,
+    #   content:,
+    #   message_type:,
+    #   sent_at:
+    # )
   end
 end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -32,9 +32,9 @@ module BattleStadium
       hostname = Socket.gethostname
 
       ENV["POSTGRES_HOST"] = hostname == "rails-api-container" ? "postgres" : "localhost"
+      redis_host = hostname == "rails-api-container" ? "redis" : "localhost"
+      ENV["REDIS_URL"] ||= "redis://#{redis_host}:6379/1"
       ENV["DATABASE_URL"] = nil
-
-      ENV["REDIS_URL"] ||= "redis://redis:6379/1"
 
       errors = []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - postgres
       - redis
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://backend/up"]
+      test: ["CMD", "curl", "-f", "http://backend:10000/up"]
       interval: 60s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,31 @@ services:
     ports:
       - 6379:6379
 
+  sidekiq:
+    image: thatguyinabeanie/battle-stadium:dev-latest
+    command: zsh -c "(bundle check || bundle install) && bundle exec sidekiq"
+    environment:
+      RAILS_ENV: development
+      ADMIN_BYPASS: "true"
+      REDIS_URL: redis://redis:6379/1
+    ports:
+      - 10001:3000
+    build:
+      context: backend
+      dockerfile: Dockerfile.dev
+      target: development
+      tags:
+        - thatguyinabeanie/battle-stadium:dev-latest
+      cache_from:
+        - thatguyinabeanie/battle-stadium:dev-latest
+    depends_on:
+      - postgres
+      - redis
+    volumes:
+      - .:/battle-stadium
+      - ./backend/.zshrc:/root/.zshenv
+      - ./backend/.zshrc:/root/.zshrc
+
   # RAILS API - DEVELOPMENT CONTAINER
   backend:
     hostname: rails-api-container


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added the `dotenv-rails` gem for improved management of environment variables across all application environments.
	- Removed the `dotenv-rails` gem from the `development, test` group to streamline its usage.
	- Introduced a new `sidekiq` service for background job processing in the Docker environment.
  
- **Bug Fixes**
	- Updated Redis configuration to dynamically set the host based on the environment, enhancing flexibility.

- **Refactor**
	- Modified the `perform` method in the `SaveChatMessageJob` class to disable chat message saving while adding a logging statement for debugging purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->