### PR TITLE
Make data-table readable again

### DIFF
--- a/packages/ui/src/components/data-table/data-table.tsx
+++ b/packages/ui/src/components/data-table/data-table.tsx
@@ -21,20 +21,22 @@ import {
 import { DataTableContext, useDataTable } from "./data-table-context";
 import { useTanstackReactTable } from "./use-tanstack-react-table";
 
+interface DataTableClassNames {
+  wrapper?: string;
+  table?: string;
+  tableHead?: string;
+  tableHeader?: string;
+  tableRow?: string;
+  tableHeaderRow?: string;
+  tableBody?: string;
+  tableCell?: string;
+}
+
 interface DataTableProps<T> {
   data: T[];
   columns: ColumnDef<T>[];
   children?: ReactNode;
-  classNames?: {
-    wrapper?: string;
-    table?: string;
-    tableHead?: string;
-    tableHeader?: string;
-    tableRow?: string;
-    tableHeaderRow?: string;
-    tableBody?: string;
-    tableCell?: string;
-  };
+  classNames?: DataTableClassNames;
   footer?: () => ReactNode;
 }
 
@@ -46,16 +48,7 @@ export default function DataTable<T extends RowData>({
   classNames,
   footer,
 }: DataTableProps<T>) {
-  const {
-    wrapper,
-    table: tableClass,
-    tableHead,
-    tableHeader,
-    tableHeaderRow,
-    tableRow,
-    tableBody,
-    tableCell = "p-2", // Example default
-  } = classNames ?? {};
+  const { wrapper, table: tableClass } = classNames ?? {};
 
   const table = useTanstackReactTable<T>(data, columns);
   return (
@@ -66,51 +59,8 @@ export default function DataTable<T extends RowData>({
 
       <div className={`${defaultWrapperClassNames} ${wrapper}`}>
         <Table className={tableClass}>
-          <TableHeader className={tableHeader}>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id} className={tableHeaderRow}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id} className={tableHead}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                ))}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody className={tableBody}>
-            {table.getRowModel().rows.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  className={tableRow}
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className={tableCell}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow className={tableRow}>
-                <TableCell
-                  colSpan={columns.length}
-                  className={`h-24 text-center ${tableCell}`}
-                >
-                  No results.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
+          <DataTableHeader<T> table={table} classNames={classNames} />
+          <DataTableBody<T> table={table} classNames={classNames} />
         </Table>
       </div>
 
@@ -118,6 +68,84 @@ export default function DataTable<T extends RowData>({
         {footer ? footer() : <DefaultFooter<T> />}
       </div>
     </DataTableContext.Provider>
+  );
+}
+
+interface DataTableInnerProps<T> {
+  table: ReactTable<T>;
+  classNames?: DataTableClassNames;
+}
+function DataTableHeader<T>({ table, classNames }: DataTableInnerProps<T>) {
+  const { tableHeader, tableHeaderRow, tableHead } = classNames ?? {};
+
+  return (
+    <TableHeader className={tableHeader}>
+      {table.getHeaderGroups().map((headerGroup) => (
+        <TableRow key={headerGroup.id} className={tableHeaderRow}>
+          {headerGroup.headers.map((header) => (
+            <TableHead key={header.id} className={tableHead}>
+              {header.isPlaceholder
+                ? null
+                : flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+            </TableHead>
+          ))}
+        </TableRow>
+      ))}
+    </TableHeader>
+  );
+}
+
+function DataTableBody<T>({ table, classNames }: DataTableInnerProps<T>) {
+  const {
+    tableBody,
+    tableRow,
+    tableCell = "p-2", // Example default
+  } = classNames ?? {};
+
+  if (table.getRowModel().rows.length === 0) {
+    return <NoResults<T> table={table} classNames={classNames} />;
+  }
+
+  return (
+    <TableBody className={tableBody}>
+      {table.getRowModel().rows.map((row) => (
+        <TableRow
+          className={tableRow}
+          key={row.id}
+          data-state={row.getIsSelected() && "selected"}
+        >
+          {row.getVisibleCells().map((cell) => (
+            <TableCell key={cell.id} className={tableCell}>
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  );
+}
+
+function NoResults<T>({ table, classNames }: DataTableInnerProps<T>) {
+  const {
+    tableBody,
+    tableRow,
+    tableCell = "p-2", // Example default
+  } = classNames ?? {};
+
+  return (
+    <TableBody className={tableBody}>
+      <TableRow className={tableRow}>
+        <TableCell
+          colSpan={table.getAllColumns().length}
+          className={`h-24 text-center ${tableCell}`}
+        >
+          No results.
+        </TableCell>
+      </TableRow>
+    </TableBody>
   );
 }
 


### PR DESCRIPTION
Refactor the DataTable component to improve readability by separating the header and body into distinct components. This enhances maintainability and clarity of the code.